### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,5 +28,5 @@ make livehtml
 
 The documentaion use the [bolt](https://github.com/mcbeet/bolt) format for mcfunction. That allow for multiline commands & nested commands.
 
-The parser also support the [SNBT](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format) format for syntax highlighting.
+The parser also support the [SNBT](https://minecraft.wiki/w/NBT_format#SNBT_format) format for syntax highlighting.
 

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -5,8 +5,8 @@
 
 ## Prerequisites
 
-- What is a [datapack](https://minecraft.fandom.com/wiki/Data_Pack)
-- What is a [function tag](https://minecraft.fandom.com/wiki/Function_(Java_Edition)#Invocation_from_function_tags)
+- What is a [datapack](https://minecraft.wiki/w/Data_Pack)
+- What is a [function tag](https://minecraft.wiki/w/Function_(Java_Edition)#Invocation_from_function_tags)
 - The `.mcfunction` syntax is the same as [Smithed](https://wiki.smithed.dev/libraries) syntax
 - Knowing how to place a custom block, consider using [Smithed Custom Block](https://wiki.smithed.dev/libraries/custom-block/)
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki